### PR TITLE
Add support for `#[serde(other)]` annotation.

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,6 +25,29 @@ mod small_prime {
     }
 }
 
+mod other {
+    use super::*;
+
+    #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+    #[repr(u8)]
+    enum TestOther {
+        A,
+        B,
+        #[serde(other, rename = "useless")]
+        Other,
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let p: TestOther = serde_json::from_str("0").unwrap();
+        assert_eq!(p, TestOther::A);
+        let p: TestOther = serde_json::from_str("1").unwrap();
+        assert_eq!(p, TestOther::B);
+        let p: TestOther = serde_json::from_str("5").unwrap();
+        assert_eq!(p, TestOther::Other);
+    }
+}
+
 mod implicit_discriminant {
     use super::*;
 

--- a/tests/ui/multiple_others.rs
+++ b/tests/ui/multiple_others.rs
@@ -1,0 +1,12 @@
+use serde_repr::Serialize_repr;
+
+#[derive(Serialize_repr)]
+#[repr(u8)]
+enum MultipleOthers {
+    #[serde(other)]
+    A,
+    #[serde(other)]
+    B,
+}
+
+fn main() {}

--- a/tests/ui/multiple_others.stderr
+++ b/tests/ui/multiple_others.stderr
@@ -1,0 +1,8 @@
+error: only one variant can be #[serde(other)]
+ --> $DIR/multiple_others.rs:3:10
+  |
+3 | #[derive(Serialize_repr)]
+  |          ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #1.