### PR TITLE
Rename the proc macro to be consistent with the standard libary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_repr"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 //! # Examples
 //!
 //! ```
-//! use serde_repr::{Serialize_repr, Deserialize_repr};
+//! use serde_repr::{SerializeRepr, DeserializeRepr};
 //!
-//! #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+//! #[derive(SerializeRepr, DeserializeRepr, PartialEq, Debug)]
 //! #[repr(u8)]
 //! enum SmallPrime {
 //!     Two = 2,
@@ -40,7 +40,7 @@ use crate::parse::Input;
 
 use std::iter;
 
-#[proc_macro_derive(Serialize_repr)]
+#[proc_macro_derive(SerializeRepr)]
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Input);
     let ident = input.ident;
@@ -68,7 +68,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(Deserialize_repr, attributes(serde))]
+#[proc_macro_derive(DeserializeRepr, attributes(serde))]
 pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Input);
     let ident = input.ident;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,9 @@
-use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde_repr::{DeserializeRepr, SerializeRepr};
 
 mod small_prime {
     use super::*;
 
-    #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+    #[derive(SerializeRepr, DeserializeRepr, PartialEq, Debug)]
     #[repr(u8)]
     enum SmallPrime {
         Two = 2,
@@ -28,7 +28,7 @@ mod small_prime {
 mod other {
     use super::*;
 
-    #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+    #[derive(SerializeRepr, DeserializeRepr, PartialEq, Debug)]
     #[repr(u8)]
     enum TestOther {
         A,
@@ -51,7 +51,7 @@ mod other {
 mod implicit_discriminant {
     use super::*;
 
-    #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+    #[derive(SerializeRepr, DeserializeRepr, PartialEq, Debug)]
     #[repr(u8)]
     enum ImplicitDiscriminant {
         Zero,

--- a/tests/ui/empty_enum.rs
+++ b/tests/ui/empty_enum.rs
@@ -1,6 +1,6 @@
-use serde_repr::Serialize_repr;
+use serde_repr::SerializeRepr;
 
-#[derive(Serialize_repr)]
+#[derive(SerializeRepr)]
 enum SmallPrime {}
 
 fn main() {}

--- a/tests/ui/empty_enum.stderr
+++ b/tests/ui/empty_enum.stderr
@@ -1,7 +1,5 @@
 error: there must be at least one variant
  --> $DIR/empty_enum.rs:3:10
   |
-3 | #[derive(Serialize_repr)]
-  |          ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+3 | #[derive(SerializeRepr)]
+  |          ^^^^^^^^^^^^^

--- a/tests/ui/empty_enum.stderr
+++ b/tests/ui/empty_enum.stderr
@@ -3,3 +3,5 @@ error: there must be at least one variant
   |
 3 | #[derive(SerializeRepr)]
   |          ^^^^^^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing_repr.rs
+++ b/tests/ui/missing_repr.rs
@@ -1,6 +1,6 @@
-use serde_repr::Serialize_repr;
+use serde_repr::SerializeRepr;
 
-#[derive(Serialize_repr)]
+#[derive(SerializeRepr)]
 enum SmallPrime {
     Two = 2,
     Three = 3,

--- a/tests/ui/missing_repr.stderr
+++ b/tests/ui/missing_repr.stderr
@@ -3,3 +3,5 @@ error: missing #[repr(...)] attribute
   |
 3 | #[derive(SerializeRepr)]
   |          ^^^^^^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing_repr.stderr
+++ b/tests/ui/missing_repr.stderr
@@ -1,7 +1,5 @@
 error: missing #[repr(...)] attribute
  --> $DIR/missing_repr.rs:3:10
   |
-3 | #[derive(Serialize_repr)]
-  |          ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+3 | #[derive(SerializeRepr)]
+  |          ^^^^^^^^^^^^^

--- a/tests/ui/multiple_others.rs
+++ b/tests/ui/multiple_others.rs
@@ -1,6 +1,6 @@
-use serde_repr::Deserialize_repr;
+use serde_repr::DeserializeRepr;
 
-#[derive(Deserialize_repr)]
+#[derive(DeserializeRepr)]
 #[repr(u8)]
 enum MultipleOthers {
     #[serde(other)]

--- a/tests/ui/multiple_others.stderr
+++ b/tests/ui/multiple_others.stderr
@@ -1,7 +1,5 @@
 error: only one variant can be #[serde(other)]
  --> $DIR/multiple_others.rs:3:10
   |
-3 | #[derive(Deserialize_repr)]
-  |          ^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+3 | #[derive(DeserializeRepr)]
+  |          ^^^^^^^^^^^^^^^

--- a/tests/ui/multiple_others.stderr
+++ b/tests/ui/multiple_others.stderr
@@ -3,3 +3,5 @@ error: only one variant can be #[serde(other)]
   |
 3 | #[derive(DeserializeRepr)]
   |          ^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/non_unit_variant.rs
+++ b/tests/ui/non_unit_variant.rs
@@ -1,6 +1,6 @@
-use serde_repr::Serialize_repr;
+use serde_repr::SerializeRepr;
 
-#[derive(Serialize_repr)]
+#[derive(SerializeRepr)]
 #[repr(u8)]
 enum SmallPrime {
     Two(u8),

--- a/tests/ui/not_enum.rs
+++ b/tests/ui/not_enum.rs
@@ -1,6 +1,6 @@
-use serde_repr::Serialize_repr;
+use serde_repr::SerializeRepr;
 
-#[derive(Serialize_repr)]
+#[derive(SerializeRepr)]
 struct SmallPrime {
     two: u8,
     three: u8,

--- a/tests/ui/not_enum.stderr
+++ b/tests/ui/not_enum.stderr
@@ -3,3 +3,5 @@ error: input must be an enum
   |
 3 | #[derive(SerializeRepr)]
   |          ^^^^^^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/not_enum.stderr
+++ b/tests/ui/not_enum.stderr
@@ -1,7 +1,5 @@
 error: input must be an enum
  --> $DIR/not_enum.rs:3:10
   |
-3 | #[derive(Serialize_repr)]
-  |          ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+3 | #[derive(SerializeRepr)]
+  |          ^^^^^^^^^^^^^


### PR DESCRIPTION
Currently the procedural macro's that are exported by this crate are exported under the name `Serialize_repr` and `Deserialize_repr`. The proc macros in the standard library however, are exported under a different casing convention, namely PascalCase. An example of this is `PartialEq`. This pull request makes the breaking change of renaming the macros to `SerializeRepr` and `DeserializeRepr`. It also updates the tests so that they pass with this new name, and it updates the documentation to reflect this change. I have also incremented the version to `0.2.0`, as this is a breaking change. 

I'm not sure if you feel this change is worth the breakage, so feel free to close this pull request if you disagree. 