### PR TITLE
Allow clippy::use_self lint in generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let match_variants = input.variants.iter().map(|variant| {
         let variant = &variant.ident;
         quote! {
+            #[allow(clippy::use_self)]
             #ident::#variant => #ident::#variant as #repr,
         }
     });
@@ -94,6 +95,7 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let match_discriminants = input.variants.iter().map(|variant| {
         let variant = &variant.ident;
         quote! {
+            #[allow(clippy::use_self)]
             discriminant::#variant => core::result::Result::Ok(#ident::#variant),
         }
     });


### PR DESCRIPTION
Fixes #12.

An alternative solution would be to use `Self::#variant` in the actual generation itself, but since this shouldn't be a logical change just suppressing the lint seemed the best choice.