### PR TITLE
Allow non_camel_case_types in generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
             where
                 D: serde::Deserializer<'de>,
             {
+                #[allow(non_camel_case_types)]
                 struct discriminant;
 
                 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
Prevents warning when using the Deserialize_repr and Serialize_repr macros, as the `discriminant` struct created in the expanded code is all lowercase:

```
Structure `discriminant` should have CamelCase name, e.g. `Discriminant` rust-analyzer(non_camel_case_types)
```