### PR TITLE
Use rooted path to refer to ::core in generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         impl serde::Serialize for #ident {
             #[allow(clippy::use_self)]
-            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> ::core::result::Result<S::Ok, S::Error>
             where
                 S: serde::Serializer
             {
@@ -93,7 +93,7 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let match_discriminants = input.variants.iter().map(|variant| {
         let variant = &variant.ident;
         quote! {
-            discriminant::#variant => core::result::Result::Ok(#ident::#variant),
+            discriminant::#variant => ::core::result::Result::Ok(#ident::#variant),
         }
     });
 
@@ -107,11 +107,11 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
         Some(variant) => {
             let variant = &variant.ident;
             quote! {
-                core::result::Result::Ok(#ident::#variant)
+                ::core::result::Result::Ok(#ident::#variant)
             }
         }
         None => quote! {
-            core::result::Result::Err(serde::de::Error::custom(
+            ::core::result::Result::Err(serde::de::Error::custom(
                 format_args!(#error_format, other #(, discriminant::#variants)*)
             ))
         },
@@ -120,7 +120,7 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         impl<'de> serde::Deserialize<'de> for #ident {
             #[allow(clippy::use_self)]
-            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> ::core::result::Result<Self, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {


### PR DESCRIPTION
Closes #14.