### PR TITLE
Mention serde_repr in error message

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -69,7 +69,7 @@ impl Parse for Input {
                     })
                 }
                 Fields::Named(_) | Fields::Unnamed(_) => {
-                    Err(Error::new(variant.ident.span(), "must be a unit variant"))
+                    Err(Error::new(variant.ident.span(), "must be a unit variant to use serde_repr derive"))
                 }
             })
             .collect::<Result<Vec<Variant>>>()?;

--- a/tests/ui/non_unit_variant.stderr
+++ b/tests/ui/non_unit_variant.stderr
@@ -1,4 +1,4 @@
-error: must be a unit variant
+error: must be a unit variant to use serde_repr derive
  --> tests/ui/non_unit_variant.rs:6:5
   |
 6 |     Two(u8),


### PR DESCRIPTION
Without this, it can be disorienting where the error came from.

Closes #23.