### PR TITLE
feat: #31 support #[serde(untagged)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,19 +47,67 @@ use syn::parse_macro_input;
 
 use crate::parse::Input;
 
+fn build_numerics_enum(
+    ident: &syn::Ident,
+    variants: &[parse::Variant],
+) -> proc_macro2::TokenStream {
+    let fields = variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        if variant.attrs.is_untagged {
+            quote! {}
+        } else if let Some(discriminant) = &variant.discriminant {
+            let expr = &discriminant.1;
+            quote! {
+                #variant_ident = #expr,
+            }
+        } else {
+            quote! {
+                #variant_ident,
+            }
+        }
+    });
+    quote!(
+        #[allow(non_camel_case_types)]
+        enum #ident {
+            #( #fields )*
+        }
+    )
+}
+
 #[proc_macro_derive(Serialize_repr)]
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Input);
     let ident = input.ident;
     let repr = input.repr;
 
+    let has_untagged_variant = input
+        .default_variant
+        .as_ref()
+        .map_or(false, |v| v.attrs.is_untagged);
+
+    let numeric_ident = if has_untagged_variant {
+        syn::Ident::new(&format!("NumericOnly{}", ident), ident.span())
+    } else {
+        ident.clone()
+    };
+    let numerics_only = if has_untagged_variant {
+        build_numerics_enum(&numeric_ident, &input.variants)
+    } else {
+        quote! {}
+    };
+
     let match_variants = input.variants.iter().map(|variant| {
-        let variant = &variant.ident;
-        quote! {
-            #ident::#variant => #ident::#variant as #repr,
+        let variant_ident = &variant.ident;
+        if variant.attrs.is_untagged {
+            quote! {
+                #ident::#variant_ident(inner) => inner as #repr,
+            }
+        } else {
+            quote! {
+                #ident::#variant_ident => #numeric_ident::#variant_ident as #repr,
+            }
         }
     });
-
     TokenStream::from(quote! {
         #[allow(deprecated)]
         impl serde::Serialize for #ident {
@@ -68,6 +116,8 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
             where
                 S: serde::Serializer
             {
+                #numerics_only
+
                 let value: #repr = match *self {
                     #(#match_variants)*
                 };
@@ -84,17 +134,41 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let repr = input.repr;
     let variants = input.variants.iter().map(|variant| &variant.ident);
 
+    let has_untagged_variant = input
+        .default_variant
+        .as_ref()
+        .map_or(false, |v| v.attrs.is_untagged);
+
+    let numeric_ident = if has_untagged_variant {
+        syn::Ident::new(&format!("NumericOnly{}", ident), ident.span())
+    } else {
+        ident.clone()
+    };
+    let numerics_only_enum = if has_untagged_variant {
+        build_numerics_enum(&numeric_ident, &input.variants)
+    } else {
+        quote! {}
+    };
+
     let declare_discriminants = input.variants.iter().map(|variant| {
-        let variant = &variant.ident;
-        quote! {
-            const #variant: #repr = #ident::#variant as #repr;
+        let variant_ident = &variant.ident;
+        if variant.attrs.is_untagged {
+            quote! {}
+        } else {
+            quote! {
+                const #variant_ident: #repr = #numeric_ident::#variant_ident as #repr;
+            }
         }
     });
 
     let match_discriminants = input.variants.iter().map(|variant| {
-        let variant = &variant.ident;
-        quote! {
-            discriminant::#variant => ::core::result::Result::Ok(#ident::#variant),
+        let variant_ident = &variant.ident;
+        if variant.attrs.is_untagged {
+            quote! {}
+        } else {
+            quote! {
+                discriminant::#variant_ident => ::core::result::Result::Ok(#ident::#variant_ident),
+            }
         }
     });
 
@@ -106,9 +180,19 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
 
     let other_arm = match input.default_variant {
         Some(variant) => {
-            let variant = &variant.ident;
-            quote! {
-                ::core::result::Result::Ok(#ident::#variant)
+            if variant.attrs.is_default {
+                let variant = &variant.ident;
+                quote! {
+                    ::core::result::Result::Ok(#ident::#variant)
+                }
+            } else if variant.attrs.is_untagged {
+                quote! {
+                    ::core::result::Result::Ok(#ident::Other(other))
+                }
+            } else {
+                quote! {
+                    This Should Never Happen!
+                }
             }
         }
         None => quote! {
@@ -126,6 +210,8 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
             where
                 D: serde::Deserializer<'de>,
             {
+                #numerics_only_enum
+
                 #[allow(non_camel_case_types)]
                 struct discriminant;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -79,3 +79,38 @@ mod implicit_discriminant {
         assert_eq!(p, ImplicitDiscriminant::Two);
     }
 }
+
+mod untagged {
+    use super::*;
+
+    #[derive(Serialize_repr, Deserialize_repr, Debug, PartialEq)]
+    #[repr(u8)]
+    enum Untagged {
+        A,
+        B = 1 + 3,
+        C = 8,
+        #[serde(untagged)]
+        Other(u8),
+    }
+
+    #[test]
+    fn test_serialize() {
+        let j = serde_json::to_string(&Untagged::C).unwrap();
+        assert_eq!(j, "8");
+
+        let j = serde_json::to_string(&Untagged::B).unwrap();
+        assert_eq!(j, "4");
+
+        let j = serde_json::to_string(&Untagged::Other(25)).unwrap();
+        assert_eq!(j, "25");
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let p: Untagged = serde_json::from_str("4").unwrap();
+        assert_eq!(p, Untagged::B);
+
+        let p: Untagged = serde_json::from_str("5").unwrap();
+        assert_eq!(p, Untagged::Other(5));
+    }
+}

--- a/tests/ui/mixed_others_untagged.rs
+++ b/tests/ui/mixed_others_untagged.rs
@@ -1,0 +1,12 @@
+use serde_repr::Deserialize_repr;
+
+#[derive(Deserialize_repr)]
+#[repr(u8)]
+enum MixedOthersUntagged {
+    #[serde(untagged)]
+    A,
+    #[serde(other)]
+    B,
+}
+
+fn main() {}

--- a/tests/ui/mixed_others_untagged.stderr
+++ b/tests/ui/mixed_others_untagged.stderr
@@ -1,5 +1,5 @@
 error: only one variant can be #[serde(other)] or #[serde(untagged)]
- --> tests/ui/multiple_others.rs:3:10
+ --> tests/ui/mixed_others_untagged.rs:3:10
   |
 3 | #[derive(Deserialize_repr)]
   |          ^^^^^^^^^^^^^^^^

--- a/tests/ui/non_unit_variant.stderr
+++ b/tests/ui/non_unit_variant.stderr
@@ -1,4 +1,4 @@
-error: must be a unit variant to use serde_repr derive
+error: must be a unit variant or be tagged with #[serde(untagged)] to use serde_repr derive
  --> tests/ui/non_unit_variant.rs:6:5
   |
 6 |     Two(u8),


### PR DESCRIPTION
Adding support for #[serde(untagged)] by optionally inserting Enums with only the numeric fields to leave as much as the original code intact.