### PR TITLE
Rename `Serialize_repr` to `SerializeRepr`, and `Deserialize_repr` to `DeserializeRepr`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.2.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["encoding", "no-std", "no-std::no-alloc"]
 description = "Derive Serialize and Deserialize that delegates to the underlying repr of a C-like enum."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/serde_repr/0.1.20")]
+#![doc(html_root_url = "https://docs.rs/serde_repr/0.2.0")]
 #![allow(clippy::single_match_else)]
 
 extern crate proc_macro;
@@ -47,9 +47,7 @@ use syn::parse_macro_input;
 
 use crate::parse::Input;
 
-#[proc_macro_derive(Serialize_repr)]
-pub fn derive_serialize(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as Input);
+fn expand_serialize(input: Input) -> TokenStream {
     let ident = input.ident;
     let repr = input.repr;
 
@@ -77,9 +75,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(Deserialize_repr, attributes(serde))]
-pub fn derive_deserialize(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as Input);
+fn expand_deserialize(input: Input) -> TokenStream {
     let ident = input.ident;
     let repr = input.repr;
     let variants = input.variants.iter().map(|variant| &variant.ident);
@@ -141,4 +137,34 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
             }
         }
     })
+}
+
+#[proc_macro_derive(SerializeRepr)]
+pub fn derive_serialize(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+
+    expand_serialize(input)
+}
+
+#[proc_macro_derive(DeserializeRepr, attributes(serde))]
+pub fn derive_deserialize(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+    
+    expand_deserialize(input)
+}
+
+#[deprecated]
+#[proc_macro_derive(Serialize_repr)]
+pub fn derive_serialize_legacy(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+
+    expand_serialize(input)
+}
+
+#[deprecated]
+#[proc_macro_derive(Deserialize_repr, attributes(serde))]
+pub fn derive_deserialize_legacy(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+    
+    expand_deserialize(input)
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,6 +3,7 @@
     // Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
     clippy::nonstandard_macro_braces,
     clippy::wildcard_imports,
+    deprecated,
 )]
 
 use serde_repr::{Deserialize_repr, Serialize_repr};


### PR DESCRIPTION
This project isn't really following the convention of using PascalCase for the derive macros. I am opening this PR to ask for this to change.

This is just a proposal; feel free to close this and implement it however you want. What I did here was:

1. bump the minor version (to v0.2.0) since this is a considerable public API change,
3. extract the logic of derive macros into the functions `extend_serialize` and `extend_deserialize`,
4. create two new derive macros named `SerializeRepr` and `DeserializeRepr`,
5. set both the existing and new derive macros to use the extracted functions, and
6. mark the old derive macros `Serialize_repr` and `Deserialize_repr` as deprecated, maintaining compatibility.

If you chose to go down this path you should consider adapting documentation and tests, since the only thing I changed there is a simple allow clause to avoid warnings for the use of the now-deprecated `Serialize_repr` and `Deserialize_repr`.